### PR TITLE
Fix adminLayout.html closing tags

### DIFF
--- a/adminLayout.html
+++ b/adminLayout.html
@@ -156,5 +156,7 @@
     });
 
     // Cancel button behavior (reload page to revert changes)
-    document.getElementById('cancelBtn').addEventListener('click', function () {location.reload();});
+document.getElementById('cancelBtn').addEventListener('click', function () {location.reload();});
 </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add missing `</body>` and `</html>` tags to close the admin layout

## Testing
- `go build ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68512f64479c832499a8e0e77f1cef25