### PR TITLE
Fix MP3 filename case

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ func loadMessagesFromJSONfile() {
 
 // saveMessagesToJSONfile saves the messages to a JSON file.
 func saveMessagesToJSONfile() {
-	if err := PlayMP3("alarm05.mp3"); err != nil {
+	if err := PlayMP3("Alarm05.mp3"); err != nil {
 		logF(err)
 	}
 	jsonBytes, err := json.MarshalIndent(messages, "", "  ")


### PR DESCRIPTION
## Summary
- fix `saveMessagesToJSONfile` to play `Alarm05.mp3`

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*
- `go test ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68512f43ce448324a343abada058e0e1