### PR TITLE
Handle ready from oto.NewContext

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,8 +247,19 @@ func getOtoContext() (*oto.Context, error) {
 	}
 
 	var err error
-	otoCtx, _, err = oto.NewContext(op)
-	return otoCtx, err
+	var ready func() error
+	otoCtx, ready, err = oto.NewContext(op)
+	if err != nil {
+		return nil, err
+	}
+
+	if ready != nil {
+		if err = ready(); err != nil {
+			return nil, err
+		}
+	}
+
+	return otoCtx, nil
 }
 
 func logFMessages() {


### PR DESCRIPTION
## Summary
- call the `ready` function returned by `oto.NewContext`
- propagate any errors from `ready()`

## Testing
- `go vet ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68512f8c78a483248154884227a0b508